### PR TITLE
migrated spring.factories to META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports

### DIFF
--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,1 +1,0 @@
-org.springframework.boot.autoconfigure.EnableAutoConfiguration=com.bol.config.EncryptAutoConfiguration

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.bol.config.EncryptAutoConfiguration


### PR DESCRIPTION

configuration beans will not be read from spring.factories in the springboot 3.2. 